### PR TITLE
Clear the job search queue on toggle.

### DIFF
--- a/script/companion.lua
+++ b/script/companion.lua
@@ -1518,6 +1518,10 @@ local recall_constructing_robots = function(player)
   end
 end
 
+local clear_specific_job_search_queue = function(player)
+  script_data.specific_job_search_queue[player.index] = nil
+end
+
 local on_lua_shortcut = function(event)
   local player = game.get_player(event.player_index)
   local name = event.prototype_name
@@ -1528,6 +1532,7 @@ local on_lua_shortcut = function(event)
   if name == "companion-construction-toggle" then
     player.set_shortcut_toggled(name, not player.is_shortcut_toggled(name))
     recall_constructing_robots(player)
+    clear_specific_job_search_queue(player)
   end
 end
 


### PR DESCRIPTION
Sometimes the drones would get stuck and not respond to any construction work around the player. Now toggling the construction will clear their job search queue, which has been observed to help in such situations.

Note: This is not a proper fix against such situations, but rather a workaround, but still an effective one, and it actually makes sense overall.