### PR TITLE
Add a fallback for players moving surfaces

### DIFF
--- a/script/companion.lua
+++ b/script/companion.lua
@@ -1382,7 +1382,11 @@ local on_player_changed_surface = function(event)
   if not player.character then
     --For the space exploration satellite viewer thing...
     --If there is no character, lets just not go with the player.
-    return
+    if remote.interfaces["space-exploration"]["remote_view_is_active"] and
+       remote.call("space-exploration", "remote_view_is_active", {player=player})
+    then
+      return
+    end
   end
   local surface = player.surface
   local position = player.position


### PR DESCRIPTION
Space Exploration has a navigation mode that creates a fake
player on other surfaces to view them from a 'satellite'. In the
existing code, any time that there isn't a character body, the robots
don't follow. Unfortunately, there also isn't a body for some cutscenes
that happen on transitions to other worlds.

Use the sanctioned interface to check if we're using the sat view vs
actually arriving somewhere else in a cutscene.

There are more sat view bugs, but not leaving the bots behind makes
them less likely to occur.